### PR TITLE
Update package.json to include the repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "2.0.3",
   "description": "marko-starter plugin that configures Babel",
   "main": "index.js",
-  "repository": {},
   "author": "Phillip Gates-Idem <phillip.idem@gmail.com>",
   "license": "MIT",
   "devDependencies": {
     "eslint": "^3.13.0",
     "eslint-config-marko": "^1.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marko-js-archive/marko-starter-lasso.git"
   },
   "dependencies": {
     "@lasso/marko-taglib": "^1.0.13",


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources. 

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR. 

Published NPM packages with repository information:
• marko-starter-lasso